### PR TITLE
Cargar desde Json. repartirPaises mejorado

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,11 @@
             <version>${mockito-mockito-core-version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.7</version>
+        </dependency>
     </dependencies>
     <profiles>
         <profile>

--- a/src/main/java/edu/fiuba/algo3/modelo/CargarJuego.java
+++ b/src/main/java/edu/fiuba/algo3/modelo/CargarJuego.java
@@ -1,0 +1,69 @@
+package edu.fiuba.algo3.modelo;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import com.google.gson.*;
+
+public class CargarJuego {
+
+
+
+    public static void cargarPaisesAlTablero(Tablero tablero, String archivoPaises) throws IOException {
+        HashMap<Pais, ArrayList<String>> limitrofes = new HashMap<>();
+        HashMap<String, Pais> paises = new HashMap<>();
+        InputStream is = CargarJuego.class.getClassLoader().getResourceAsStream(archivoPaises);
+        String json = new String(is != null ? is.readAllBytes() : new byte[0], StandardCharsets.UTF_8);
+        GsonBuilder gsonBuilder = new GsonBuilder();
+
+
+        // Deserializer. Guarda cada Pais en "paises" y el nombre de los limitrofes en "limitrofes"
+        JsonDeserializer<Pais> deserializer = (jsonElement, type, jsonDeserializationContext) -> {
+            JsonObject jsonObject = jsonElement.getAsJsonObject();
+
+            //Crea el objeto pais sin limitrofes
+            String nombrePais = jsonObject.get("Pais").getAsString();
+
+            Pais pais = new Pais(
+                    nombrePais,
+                    jsonObject.get("Continente").getAsString()
+            );
+            paises.put(nombrePais, pais);
+            limitrofes.put(pais, new ArrayList<>());
+
+            String nombresLimitrofes = jsonObject.get("Limita con").getAsString();
+            String[] arrayNombreLimitrofes = nombresLimitrofes.split(",");
+            for (String limitrofe : arrayNombreLimitrofes) {
+                limitrofes.get(pais).add(limitrofe);
+            }
+            return pais;
+        };
+
+        gsonBuilder.registerTypeAdapter(Pais.class, deserializer);
+        Gson gson = gsonBuilder.create();
+
+        Pais[] _paises = gson.fromJson(json, Pais[].class);
+
+        // Agrega a cada pais sus limitrofes
+        for (Pais pais: _paises){
+            ArrayList<String> nombreLimitrofes = limitrofes.get(pais);
+            for (String limitrofe: nombreLimitrofes) {
+                pais.limitaCon(paises.get(limitrofe));
+            }
+            tablero.agregarPais(pais);
+        }
+    }
+
+
+
+
+    // Falta Implementar la gestion de tarjetas
+    /* public static void cargarTarjetas(Object tarjetas, String archivoTarjetas) throws IOException{
+
+    }
+    */
+
+}

--- a/src/main/java/edu/fiuba/algo3/modelo/Juego.java
+++ b/src/main/java/edu/fiuba/algo3/modelo/Juego.java
@@ -1,18 +1,28 @@
 package edu.fiuba.algo3.modelo;
-import java.io.BufferedReader;
-import java.io.FileReader;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
-import java.util.Random;
+
 
 public class Juego {
-    static final String NOMBRE_ARCHIVO = "paises.txt";//"C:/Users/franm/OneDrive/Documentos/Algo III/algo3_tp2/src/main/java/edu/fiuba/algo3/modelo/paises.txt";
+    static final String ARCHIVO_PAISES = "paises.json";
+    static final String ARCHIVO_TARJETAS = "tarjetas.json";
+
     private Tablero tablero;
     private ArrayList<Jugador> jugadores;
 
     public Juego() {
         jugadores = new ArrayList<>();
         tablero = new Tablero();
+        try {
+            CargarJuego.cargarPaisesAlTablero(tablero, ARCHIVO_PAISES);
+            //CargarJuego.cargarTarjetas(tarjetas, ARCHIVO_TARJETAS);
+        }
+        //Error al cargar los archivos
+        catch (Exception e) {
+            System.out.println(e.getMessage());
+        }
     }
 
     public void agregarJugador(Jugador unJugador) {
@@ -20,62 +30,14 @@ public class Juego {
     }
 
     public void comenzar() throws CantidadDeJugadoresInsuficienteException, PaisOcupadoPorOtroJugadorException {
-        inicializarPaisesDesdeArchivo(NOMBRE_ARCHIVO);
         if (jugadores.size() < 2) throw new CantidadDeJugadoresInsuficienteException();
         else tablero.repartirPaises(jugadores);
 
     }
 
     public void repartirPaises() throws PaisOcupadoPorOtroJugadorException {
-
         tablero.repartirPaises(jugadores);
 
     }
 
-    private void inicializarPaisesDesdeArchivo(String nombreArchivo) {
-        // nombrePais:limitrofe1,limitrofe2,...,limitrofeN
-
-        BufferedReader bufferLectura = null;
-        try {
-            // Abrir el .csv en buffer de lectura
-            bufferLectura = new BufferedReader(new FileReader(nombreArchivo));
-
-            // Leer una linea del archivo
-            String linea = bufferLectura.readLine();
-
-            while (linea != null) {
-                String[] campos = linea.split(":");
-                Pais nuevoPais;
-                if (tablero.obtenerPais(campos[0]) == null) {
-                    nuevoPais = new Pais(campos[0]);
-                    tablero.agregarPais(campos[0], nuevoPais);
-                } else nuevoPais = tablero.obtenerPais(campos[0]);
-
-                String[] paisesLimitrofes = campos[1].split(",");
-
-                for (int i = 0; i < paisesLimitrofes.length; i++) {
-                    if (tablero.obtenerPais(paisesLimitrofes[i]) == null) {
-                        Pais nuevoLimitrofe = new Pais(paisesLimitrofes[i]);
-                        tablero.agregarPais(paisesLimitrofes[i], nuevoLimitrofe);
-                        nuevoPais.limitaCon(nuevoLimitrofe);
-                    } else nuevoPais.limitaCon(tablero.obtenerPais(paisesLimitrofes[i]));
-                }
-                linea = bufferLectura.readLine();
-            }
-        }
-        catch (IOException e) {
-            e.printStackTrace();
-        }
-        finally {
-            // Cierro el buffer de lectura
-            if (bufferLectura != null) {
-                try {
-                    bufferLectura.close();
-                }
-                catch (IOException e) {
-                    e.printStackTrace();
-                }
-            }
-        }
-    }
 }

--- a/src/main/java/edu/fiuba/algo3/modelo/Juego.java
+++ b/src/main/java/edu/fiuba/algo3/modelo/Juego.java
@@ -21,7 +21,7 @@ public class Juego {
         }
         //Error al cargar los archivos
         catch (Exception e) {
-            System.out.println(e.getMessage());
+            e.printStackTrace();
         }
     }
 

--- a/src/main/java/edu/fiuba/algo3/modelo/Juego.java
+++ b/src/main/java/edu/fiuba/algo3/modelo/Juego.java
@@ -15,14 +15,6 @@ public class Juego {
     public Juego() {
         jugadores = new ArrayList<>();
         tablero = new Tablero();
-        try {
-            CargarJuego.cargarPaisesAlTablero(tablero, ARCHIVO_PAISES);
-            //CargarJuego.cargarTarjetas(tarjetas, ARCHIVO_TARJETAS);
-        }
-        //Error al cargar los archivos
-        catch (Exception e) {
-            e.printStackTrace();
-        }
     }
 
     public void agregarJugador(Jugador unJugador) {
@@ -30,13 +22,16 @@ public class Juego {
     }
 
     public void comenzar() throws CantidadDeJugadoresInsuficienteException, PaisOcupadoPorOtroJugadorException {
+        try {
+            CargarJuego.cargarPaisesAlTablero(tablero, ARCHIVO_PAISES);
+            //CargarJuego.cargarTarjetas(tarjetas, ARCHIVO_TARJETAS);
+        }
+
+        //Error al cargar los archivos
+        catch (Exception e) {e.printStackTrace();}
+
         if (jugadores.size() < 2) throw new CantidadDeJugadoresInsuficienteException();
         else tablero.repartirPaises(jugadores);
-
-    }
-
-    public void repartirPaises() throws PaisOcupadoPorOtroJugadorException {
-        tablero.repartirPaises(jugadores);
 
     }
 

--- a/src/main/java/edu/fiuba/algo3/modelo/Pais.java
+++ b/src/main/java/edu/fiuba/algo3/modelo/Pais.java
@@ -5,12 +5,20 @@ import java.util.Arrays;
 
 public class Pais {
     String nombre;
+    String continente;
     Fichas ejercito;
     private ArrayList<Pais> paisesLimitrofes;
 
     public Pais(String nombre) {
         this.nombre = nombre;
-        this.paisesLimitrofes = new ArrayList<Pais>();
+        this.paisesLimitrofes = new ArrayList<>();
+        this.ejercito = new EjercitoNulo();
+
+    }
+    public Pais(String nombre, String continente){
+        this.nombre = nombre;
+        this.continente = continente;
+        this.paisesLimitrofes = new ArrayList<>();
         this.ejercito = new EjercitoNulo();
     }
 

--- a/src/main/java/edu/fiuba/algo3/modelo/Tablero.java
+++ b/src/main/java/edu/fiuba/algo3/modelo/Tablero.java
@@ -1,9 +1,9 @@
 package edu.fiuba.algo3.modelo;
 import java.util.*;
+import java.util.stream.Collectors;
 
 
 public class Tablero {
-    static final int CANTIDAD_PAISES = 6; // tiene que ser 50 pero es 6 para testear
     private Map<String,Pais> paises;
     private ArrayList<String> nombresPaises;
 
@@ -16,19 +16,18 @@ public class Tablero {
         paises.put(nombrePais, unPais);
         nombresPaises.add(nombrePais);
     }
+    public void agregarPais(Pais pais){
+        paises.put(pais.nombre, pais);
+    }
 
     public void repartirPaises(ArrayList<Jugador> jugadores) throws PaisOcupadoPorOtroJugadorException {
-        Random r = new Random();
-        int numeroJugador = 0; // seria el jugador 1 xd
-        String nombrePaisActual;
-        while ((nombresPaises.size()-1) > 0) {
-            nombrePaisActual = nombresPaises.get(r.nextInt((nombresPaises.size()-1)+1));
-            jugadores.get(numeroJugador).colocarEjercitos(1, paises.get(nombrePaisActual));
-            nombresPaises.remove(nombrePaisActual);
-            numeroJugador++;
-            if (numeroJugador >= jugadores.size()) numeroJugador = 0;
+        ArrayList<Pais> _paises = new ArrayList<>(paises.values());
+        Collections.shuffle(_paises);
+
+        int cant_jugadores = jugadores.size();
+        for (int i = 0; i < paises.size(); i++) {
+            jugadores.get(i % cant_jugadores).colocarEjercitos(1, _paises.get(i));
         }
-        jugadores.get(numeroJugador).colocarEjercitos(1, paises.get(nombresPaises.get(0)));
     }
 
     public Pais obtenerPais(String nombrePais) {

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -1,4 +1,5 @@
 module edu.fiuba.algo3 {
     requires javafx.controls;
+    requires com.google.gson;
     exports edu.fiuba.algo3;
 }

--- a/src/main/resources/paises.json
+++ b/src/main/resources/paises.json
@@ -1,0 +1,252 @@
+[
+ {
+   "Pais": "Francia",
+   "Continente": "Europa",
+   "Limita con": "Alemania,España,Italia"
+ },
+ {
+   "Pais": "Gran Bretaña",
+   "Continente": "Europa",
+   "Limita con": "Islandia,Alemania,España"
+ },
+ {
+   "Pais": "Tartaria",
+   "Continente": "Asia",
+   "Limita con": "Aral,Taymir,Siberia"
+ },
+ {
+   "Pais": "Mongolia",
+   "Continente": "Asia",
+   "Limita con": "Aral,Siberia,Iran,Gobi,China"
+ },
+ {
+   "Pais": "Zaire",
+   "Continente": "Africa",
+   "Limita con": "Madagascar,Sudafrica,Etiopia,Sahara"
+ },
+ {
+   "Pais": "Polonia",
+   "Continente": "Europa",
+   "Limita con": "Alemania,Rusia,Turquia,Egipto"
+ },
+ {
+   "Pais": "Oregon",
+   "Continente": "America del Norte",
+   "Limita con": "Alaska,Yukon,Canada,Nueva York,California"
+ },
+ {
+   "Pais": "Etiopia",
+   "Continente": "Africa",
+   "Limita con": "Sahara,Egipto,Zaire,Sudafrica"
+ },
+ {
+   "Pais": "Chile",
+   "Continente": "America del Sur",
+   "Limita con": "Argentina,Peru,Australia"
+ },
+ {
+   "Pais": "Australia",
+   "Continente": "Oceania",
+   "Limita con": "Chile,Sumatra,Java,Borneo"
+ },
+ {
+   "Pais": "Kamtchatka",
+   "Continente": "Asia",
+   "Limita con": "Siberia,China,Japon,Alaska"
+ },
+ {
+   "Pais": "Egipto",
+   "Continente": "Africa",
+   "Limita con": "Polonia,Turquia,Israel,Madagascar,Etiopia,Sahara"
+ },
+ {
+   "Pais": "Turquia",
+   "Continente": "Asia",
+   "Limita con": "Egipto,Polonia,Rusia,Iran,Israel,Arabia"
+ },
+ {
+   "Pais": "Nueva York",
+   "Continente": "America del Norte",
+   "Limita con": "Groenlandia,Canada,Oregon,California,Terranova"
+ },
+ {
+   "Pais": "Terranova",
+   "Continente": "America del Norte",
+   "Limita con": "Labrador,Canada,Nueva York"
+ },
+ {
+   "Pais": "Iran",
+   "Continente": "Asia",
+   "Limita con": "Aral,Mongolia,Gobi,China,India,Turquia,Rusia"
+ },
+ {
+   "Pais": "Madagascar",
+   "Continente": "Africa",
+   "Limita con": "Egipto,Zaire"
+ },
+ {
+   "Pais": "Argentina",
+   "Continente": "America del Sur",
+   "Limita con": "Chile,Peru,Brasil,Uruguay"
+ },
+ {
+   "Pais": "Israel",
+   "Continente": "Asia",
+   "Limita con": "Turquia,Arabia,Egipto"
+ },
+ {
+   "Pais": "Rusia",
+   "Continente": "Europa",
+   "Limita con": "Suecia,Aral,Iran,Turquia,Polonia"
+ },
+ {
+   "Pais": "Borneo",
+   "Continente": "Oceania",
+   "Limita con": "Australia,Malasia"
+ },
+ {
+   "Pais": "California",
+   "Continente": "America del Norte",
+   "Limita con": "Oregon,Nueva York,Mexico"
+ },
+ {
+   "Pais": "Taymir",
+   "Continente": "Asia",
+   "Limita con": "Tartaria,Siberia"
+ },
+ {
+   "Pais": "Aral",
+   "Continente": "Asia",
+   "Limita con": "Rusia,Iran,Mongolia,Siberia,Tartaria"
+ },
+ {
+   "Pais": "Siberia",
+   "Continente": "Asia",
+   "Limita con": "Aral,Tartaria,Taymir,Kamtchatka,China,Mongolia"
+ },
+ {
+   "Pais": "Canada",
+   "Continente": "America del Norte",
+   "Limita con": "Yukon,Oregon,Nueva York,Terranova"
+ },
+ {
+   "Pais": "Sahara",
+   "Continente": "Africa",
+   "Limita con": "Brasil,España,Egipto,Etiopia,Zaire"
+ },
+ {
+   "Pais": "Yukon",
+   "Continente": "America del Norte",
+   "Limita con": "Alaska,Canada,Oregon"
+ },
+ {
+   "Pais": "Uruguay",
+   "Continente": "America del Sur",
+   "Limita con": "Argentina,Brasil"
+ },
+ {
+   "Pais": "Groenlandia",
+   "Continente": "America del Norte",
+   "Limita con": "Labrador,Nueva York,Islandia"
+ },
+ {
+   "Pais": "Japon",
+   "Continente": "Asia",
+   "Limita con": "Kamtchatka,China"
+ },
+ {
+   "Pais": "Sumatra",
+   "Continente": "Oceania",
+   "Limita con": "Australia,India"
+ },
+ {
+   "Pais": "Alaska",
+   "Continente": "America del Norte",
+   "Limita con": "Yukon,Oregon,Kamtchatka"
+ },
+ {
+   "Pais": "Brasil",
+   "Continente": "America del Sur",
+   "Limita con": "Colombia,Peru,Argentina,Uruguay,Sahara"
+ },
+ {
+   "Pais": "Gobi",
+   "Continente": "Asia",
+   "Limita con": "Mongolia,China,Iran"
+ },
+ {
+   "Pais": "Italia",
+   "Continente": "Europa",
+   "Limita con": "Alemania,Francia"
+ },
+ {
+   "Pais": "España",
+   "Continente": "Europa",
+   "Limita con": "Sahara,Francia,Gran Bretaña"
+ },
+ {
+   "Pais": "Colombia",
+   "Continente": "America del Sur",
+   "Limita con": "Mexico,Peru,Brasil"
+ },
+ {
+   "Pais": "Suecia",
+   "Continente": "Europa",
+   "Limita con": "Rusia,Islandia"
+ },
+ {
+   "Pais": "Sudafrica",
+   "Continente": "Africa",
+   "Limita con": "Zaire,Etiopia"
+ },
+ {
+   "Pais": "Arabia",
+   "Continente": "Asia",
+   "Limita con": "Turquia,Israel"
+ },
+ {
+   "Pais": "India",
+   "Continente": "Asia",
+   "Limita con": "China,Malasia,Iran,Sumatra"
+ },
+ {
+   "Pais": "Java",
+   "Continente": "Oceania",
+   "Limita con": "Australia"
+ },
+ {
+   "Pais": "Mexico",
+   "Continente": "America del Norte",
+   "Limita con": "Colombia,California"
+ },
+ {
+   "Pais": "Peru",
+   "Continente": "America del Sur",
+   "Limita con": "Colombia,Brasil,Chile,Argentina"
+ },
+ {
+   "Pais": "Alemania",
+   "Continente": "Europa",
+   "Limita con": "Polonia,Italia,Gran Bretaña,Francia"
+ },
+ {
+   "Pais": "China",
+   "Continente": "Asia",
+   "Limita con": "Kamtchatka,Siberia,Mongolia,Gobi,Iran,India,Malasia,Japon"
+ },
+ {
+   "Pais": "Labrador",
+   "Continente": "America del Norte",
+   "Limita con": "Groenlandia,Terranova"
+ },
+ {
+   "Pais": "Islandia",
+   "Continente": "Europa",
+   "Limita con": "Groenlandia,Suecia,Gran Bretaña"
+ },
+ {
+   "Pais": "Malasia",
+   "Continente": "Asia",
+   "Limita con": "China,India,Borneo"
+ }
+]

--- a/src/main/resources/tarjetas.json
+++ b/src/main/resources/tarjetas.json
@@ -1,0 +1,202 @@
+[
+ {
+   "Pais": "Francia",
+   "Simbolo": "Globo"
+ },
+ {
+   "Pais": "Gran Bretaña",
+   "Simbolo": "Barco"
+ },
+ {
+   "Pais": "Tartaria",
+   "Simbolo": "Cañon"
+ },
+ {
+   "Pais": "Mongolia",
+   "Simbolo": "Barco"
+ },
+ {
+   "Pais": "Zaire",
+   "Simbolo": "Barco"
+ },
+ {
+   "Pais": "Polonia",
+   "Simbolo": "Cañon"
+ },
+ {
+   "Pais": "Oregon",
+   "Simbolo": "Cañon"
+ },
+ {
+   "Pais": "Etiopia",
+   "Simbolo": "Globo"
+ },
+ {
+   "Pais": "Chile",
+   "Simbolo": "Globo"
+ },
+ {
+   "Pais": "Australia",
+   "Simbolo": "Cañon"
+ },
+ {
+   "Pais": "Kamtchatka",
+   "Simbolo": "Globo"
+ },
+ {
+   "Pais": "Egipto",
+   "Simbolo": "Globo"
+ },
+ {
+   "Pais": "Turquia",
+   "Simbolo": "Barco"
+ },
+ {
+   "Pais": "Nueva York",
+   "Simbolo": "Barco"
+ },
+ {
+   "Pais": "Terranova",
+   "Simbolo": "Cañon"
+ },
+ {
+   "Pais": "Iran",
+   "Simbolo": "Globo"
+ },
+ {
+   "Pais": "Madagascar",
+   "Simbolo": "Barco"
+ },
+ {
+   "Pais": "Argentina",
+   "Simbolo": "Comodin"
+ },
+ {
+   "Pais": "Israel",
+   "Simbolo": "Barco"
+ },
+ {
+   "Pais": "Rusia",
+   "Simbolo": "Globo"
+ },
+ {
+   "Pais": "Borneo",
+   "Simbolo": "Barco"
+ },
+ {
+   "Pais": "California",
+   "Simbolo": "Cañon"
+ },
+ {
+   "Pais": "Taymir",
+   "Simbolo": "Comodin"
+ },
+ {
+   "Pais": "Aral",
+   "Simbolo": "Cañon"
+ },
+ {
+   "Pais": "Siberia",
+   "Simbolo": "Barco"
+ },
+ {
+   "Pais": "Canada",
+   "Simbolo": "Cañon"
+ },
+ {
+   "Pais": "Sahara",
+   "Simbolo": "Cañon"
+ },
+ {
+   "Pais": "Yukon",
+   "Simbolo": "Globo"
+ },
+ {
+   "Pais": "Uruguay",
+   "Simbolo": "Globo"
+ },
+ {
+   "Pais": "Groenlandia",
+   "Simbolo": "Globo"
+ },
+ {
+   "Pais": "Japon",
+   "Simbolo": "Cañon"
+ },
+ {
+   "Pais": "Sumatra",
+   "Simbolo": "Globo"
+ },
+ {
+   "Pais": "Alaska",
+   "Simbolo": "Barco"
+ },
+ {
+   "Pais": "Brasil",
+   "Simbolo": "Barco"
+ },
+ {
+   "Pais": "Gobi",
+   "Simbolo": "Globo"
+ },
+ {
+   "Pais": "Italia",
+   "Simbolo": "Globo"
+ },
+ {
+   "Pais": "España",
+   "Simbolo": "Globo"
+ },
+ {
+   "Pais": "Colombia",
+   "Simbolo": "Globo"
+ },
+ {
+   "Pais": "Suecia",
+   "Simbolo": "Barco"
+ },
+ {
+   "Pais": "Sudafrica",
+   "Simbolo": "Cañon"
+ },
+ {
+   "Pais": "Arabia",
+   "Simbolo": "Cañon"
+ },
+ {
+   "Pais": "India",
+   "Simbolo": "Globo"
+ },
+ {
+   "Pais": "Java",
+   "Simbolo": "Cañon"
+ },
+ {
+   "Pais": "Mexico",
+   "Simbolo": "Cañon"
+ },
+ {
+   "Pais": "Peru",
+   "Simbolo": "Barco"
+ },
+ {
+   "Pais": "Alemania",
+   "Simbolo": "Barco"
+ },
+ {
+   "Pais": "China",
+   "Simbolo": "Barco"
+ },
+ {
+   "Pais": "Labrador",
+   "Simbolo": "Cañon"
+ },
+ {
+   "Pais": "Islandia",
+   "Simbolo": "Barco"
+ },
+ {
+   "Pais": "Malasia",
+   "Simbolo": "Cañon"
+ }
+]

--- a/src/main/test/edu/fiuba/algo3/modelo/JuegoTest.java
+++ b/src/main/test/edu/fiuba/algo3/modelo/JuegoTest.java
@@ -33,22 +33,6 @@ public class JuegoTest {
 
     }
 
-    /*@Test
-    public void esTuTurnoDeCodearYYoMeLaRascoOK() {
-        Juego juego = new Juego();
-        Jugador unJugador = new Jugador();
-        Jugador otroJugador = new Jugador();
-        juego.agregarPais("Brasil");
-        juego.agregarPais("Chile");
-        juego.agregarPais("Argentina");
-        juego.agregarPais("Bolivia");
-        juego.agregarPais("Uruguay");
-        juego.agregarPais("Paraguay");
-
-        juego.agregarJugador(unJugador);
-        juego.agregarJugador(otroJugador);
-        juego.repartirPaises();
-    }*/
 
     @Test
     public void seRepartenEquitativamenteSeisPaisesEntreDosJugadores() throws CantidadDeJugadoresInsuficienteException, PaisOcupadoPorOtroJugadorException {
@@ -59,7 +43,7 @@ public class JuegoTest {
         juego.agregarJugador(jugadorDos);
         juego.comenzar();
 
-        assertEquals(3,jugadorUno.cantidadPaisesDominados());
-        assertEquals(3,jugadorDos.cantidadPaisesDominados());
+        assertEquals(25,jugadorUno.cantidadPaisesDominados());
+        assertEquals(25,jugadorDos.cantidadPaisesDominados());
     }
 }


### PR DESCRIPTION
Agregada la funcionalidad de cargar la lista de Pais(es) y sus limitrofes desde el archivo Json. Ahora cuando se comienza el juego se carga la lista de paises

  +CargarJuego: Esta clase se encarga de leer y parsear los Pais(es). En proximas actualizaciones tambien va a parsear las Tarjeta(s)

Tablero:
Mejorada la implementacion del metódo "repartirPaises". Mezcla la lista de paises y asigna cada uno a un jugador